### PR TITLE
fix: Set version on the client before it is modified

### DIFF
--- a/app/priorclienthandler.ts
+++ b/app/priorclienthandler.ts
@@ -47,6 +47,9 @@ class PriorClientHandler extends ClientPacketHandler {
         const version = reader.readString();
         const versionMatch = version.match(/Terraria(\d+)/)
         const versionNumber = versionMatch?.[1];
+        if ((client as any).version === "unknown") {
+          (client as any).version = version;
+        }
         let isPcVersion = false;
         if (versionNumber && parseInt(versionNumber).toString() === versionNumber) {
             isPcVersion = parseInt(versionNumber) >= 234; // 1.4.1.2 or above


### PR DESCRIPTION
This allows the version to be re-evaluated each time a client switches to a different dimension, so that we can ignore changing it if the server is in the whitelist.